### PR TITLE
Added the ability to enable/disable the hack fix to allow bonus zones to sit on top of start zones in the mapsettings

### DIFF
--- a/addons/sourcemod/scripting/SurfTimer.sp
+++ b/addons/sourcemod/scripting/SurfTimer.sp
@@ -390,6 +390,7 @@ ConVar g_hMaxVelocity;
 float g_fAnnounceRecord;
 bool g_bGravityFix;
 ConVar g_hGravityFix;
+bool g_bzGrpIgnoreOverLap;
 
 /*----------  Style variables
 0 = normal, 1 = SW, 2 = HSW, 3 = BW, 4 = Low-Gravity, 5 = Slow Motion, 6 = Fast Forward

--- a/addons/sourcemod/scripting/SurfTimer/db/queries.sp
+++ b/addons/sourcemod/scripting/SurfTimer/db/queries.sp
@@ -33,7 +33,7 @@ char sql_insertLatestRecords[] = "INSERT INTO ck_latestrecords (steamid, name, r
 char sql_selectLatestRecords[] = "SELECT name, runtime, map, date FROM ck_latestrecords ORDER BY date DESC LIMIT 50";
 
 // ck_maptier
-char sql_createMapTier[] = "CREATE TABLE IF NOT EXISTS ck_maptier (mapname VARCHAR(54) NOT NULL, tier INT(12), maxvelocity FLOAT NOT NULL DEFAULT '3500.0', announcerecord INT(11) NOT NULL DEFAULT '0', gravityfix INT(11) NOT NULL DEFAULT '1', PRIMARY KEY(mapname)) DEFAULT CHARSET=utf8mb4;";
+char sql_createMapTier[] = "CREATE TABLE IF NOT EXISTS ck_maptier (mapname VARCHAR(54) NOT NULL, tier INT(12), maxvelocity FLOAT NOT NULL DEFAULT '3500.0', announcerecord INT(11) NOT NULL DEFAULT '0', gravityfix INT(11) NOT NULL DEFAULT '1', overlap INT(11) NOT NULL DEFAULT '0', PRIMARY KEY(mapname)) DEFAULT CHARSET=utf8mb4;";
 char sql_selectMapTier[] = "SELECT tier FROM ck_maptier WHERE mapname = '%s'";
 char sql_insertmaptier[] = "INSERT INTO ck_maptier (mapname, tier) VALUES ('%s', '%i');";
 char sql_updatemaptier[] = "UPDATE ck_maptier SET tier = %i WHERE mapname ='%s'";

--- a/addons/sourcemod/scripting/SurfTimer/mapsettings.sp
+++ b/addons/sourcemod/scripting/SurfTimer/mapsettings.sp
@@ -37,6 +37,11 @@ public void MapSettingsMenu(int client)
     AddMenuItem(menu, "", "Unlimit prespeed for all stage zones");
   else
     AddMenuItem(menu, "", "Unlimit prespeed for all stage zones", ITEMDRAW_DISABLED);
+	
+  if (g_bzGrpIgnoreOverLap)
+    AddMenuItem(menu, "", "don't allow bonus zones to sit on top of start zones");
+  else
+    AddMenuItem(menu, "", "Allow bonus zones to sit on top of start zones");
   
   SetMenuOptionFlags(menu, MENUFLAG_BUTTON_EXIT);
   DisplayMenu(menu, client, MENU_TIME_FOREVER);
@@ -72,6 +77,12 @@ public int MapSettingsMenuHandler(Handle menu, MenuAction action, int param1, in
       {
         db_unlimitAllStages(g_szMapName);
       }
+	  case 4:
+	  {
+		g_bzGrpIgnoreOverLap = !g_bzGrpIgnoreOverLap;
+		db_updateMapSettings();
+		MapSettingsMenu(param1);
+	  }
     }
   }
   else if (action == MenuAction_End)
@@ -204,7 +215,7 @@ public Action Command_SetGravityFix(int client, int args)
 public void db_viewMapSettings()
 {
   char szQuery[2048];
-  Format(szQuery, 2048, "SELECT `mapname`, `maxvelocity`, `announcerecord`, `gravityfix` FROM `ck_maptier` WHERE `mapname` = '%s'", g_szMapName);
+  Format(szQuery, 2048, "SELECT `mapname`, `maxvelocity`, `announcerecord`, `gravityfix`, `overlap` FROM `ck_maptier` WHERE `mapname` = '%s'", g_szMapName);
   SQL_TQuery(g_hDb, sql_viewMapSettingsCallback, szQuery, DBPrio_Low);
 }
 
@@ -222,6 +233,7 @@ public void sql_viewMapSettingsCallback(Handle owner, Handle hndl, const char[] 
       g_fMaxVelocity = SQL_FetchFloat(hndl, 1);
       g_fAnnounceRecord = SQL_FetchFloat(hndl, 2);
       g_bGravityFix = view_as<bool>(SQL_FetchInt(hndl, 3));
+      g_bzGrpIgnoreOverLap = view_as<bool>(SQL_FetchInt(hndl, 4));
     }
     setMapSettings();
   }
@@ -240,7 +252,7 @@ public void sql_insertMapSettingsCallback(Handle owner, Handle hndl, const char[
 public void db_updateMapSettings()
 {
   char szQuery[512];
-  Format(szQuery, 512, "UPDATE `ck_maptier` SET `maxvelocity` = '%f', `announcerecord` = '%f', `gravityfix` = %i WHERE `mapname` = '%s';", g_fMaxVelocity, g_fAnnounceRecord, view_as<int>(g_bGravityFix), g_szMapName);
+  Format(szQuery, 512, "UPDATE `ck_maptier` SET `maxvelocity` = '%f', `announcerecord` = '%f', `gravityfix` = %i, `overlap` = %i WHERE `mapname` = '%s';", g_fMaxVelocity, g_fAnnounceRecord, view_as<int>(g_bGravityFix), view_as<int>(g_bzGrpIgnoreOverLap), g_szMapName);
   SQL_TQuery(g_hDb, sql_insertMapSettingsCallback, szQuery, DBPrio_Low);
 }
 

--- a/addons/sourcemod/scripting/SurfTimer/surfzones.sp
+++ b/addons/sourcemod/scripting/SurfTimer/surfzones.sp
@@ -163,6 +163,7 @@ public Action StartTouchTrigger(int caller, int activator)
 	action[2] = g_mapZones[id][zoneGroup];
 
 	// Hack fix to allow bonus zones to sit on top of start zones, e.g surf_aircontrol_ksf bonus 1
+	if(g_bzGrpIgnoreOverLap)
 	if (action[0] < 6 && g_bInBonus[activator])
 	{
 		if (action[2] != g_iInBonus[activator])


### PR DESCRIPTION
i thought it might be helpful because then you can enable it only for maps that need it like sinsane or aircontrol b1 