### PR TITLE
Increase array size to reduce issues with large map names

### DIFF
--- a/addons/sourcemod/scripting/SurfTimer/sql.sp
+++ b/addons/sourcemod/scripting/SurfTimer/sql.sp
@@ -4579,8 +4579,8 @@ db_selectMapZones();
 */
 public void db_selectMapZones()
 {
-	char szQuery[270];
-	Format(szQuery, 270, sql_selectMapZones, g_szMapName);
+	char szQuery[512];
+	Format(szQuery, sizeof(szQuery), sql_selectMapZones, g_szMapName);
 	SQL_TQuery(g_hDb, SQL_selectMapZonesCallback, szQuery, 1, DBPrio_High);
 }
 

--- a/addons/sourcemod/scripting/SurfTimer/sql.sp
+++ b/addons/sourcemod/scripting/SurfTimer/sql.sp
@@ -4579,8 +4579,8 @@ db_selectMapZones();
 */
 public void db_selectMapZones()
 {
-	char szQuery[258];
-	Format(szQuery, 258, sql_selectMapZones, g_szMapName);
+	char szQuery[270];
+	Format(szQuery, 270, sql_selectMapZones, g_szMapName);
 	SQL_TQuery(g_hDb, SQL_selectMapZonesCallback, szQuery, 1, DBPrio_High);
 }
 


### PR DESCRIPTION
We figured out a small issue with large map names. 

For example:
Map -> surf_amplitude_encore_nsf_v4
Created Query: 
`SELECT zoneid, zonetype, zonetypeid, pointa_x, pointa_y, pointa_z, pointb_x, pointb_y, pointb_z, vis, team, zonegroup, zonename, hookname, targetname, onejumplimit, prespeed FROM ck_zones WHERE mapname = 'surf_amplitude_encore_nsf_v4' ORDER BY zonetypeid AS`

This fires an mysql syntax error because of the “AS” at the end (should be ASC). The array got 258 chars but the whole query needs 259. In order to minimize later problems, I have set the array size to 270. 

