### PR TITLE
minor-ish clean up

### DIFF
--- a/addons/sourcemod/scripting/SurfTimer.sp
+++ b/addons/sourcemod/scripting/SurfTimer.sp
@@ -1476,12 +1476,12 @@ char UnallowedTitles[][] =
 char g_szStyleRecordPrint[][] =
 {
 	"",
-	"*Sideways*",
-	"*Half-Sideways*",
-	"*Backwards*",
-	"*Low-Gravity*",
-	"*Slow Motion*",
-	"*Fast Forward*"
+	"* Sideways *",
+	"* Half-Sideways *",
+	"* Backwards *",
+	"* Low-Gravity *",
+	"* Slow Motion *",
+	"* Fast Forward *"
 };
 
 char g_szStyleMenuPrint[][] =

--- a/addons/sourcemod/scripting/surftimer/buttonpress.sp
+++ b/addons/sourcemod/scripting/surftimer/buttonpress.sp
@@ -84,13 +84,6 @@ public void CL_OnStartTimerPress(int client)
 				g_bMissedBonusBest[client] = false;
 
 			}
-
-			// If starting the timer for the first time, print average times
-			if (g_bFirstTimerStart[client])
-			{
-				g_bFirstTimerStart[client] = false;
-				Client_Avg(client, 0);
-			}
 		}
 	}
 

--- a/addons/sourcemod/scripting/surftimer/commands.sp
+++ b/addons/sourcemod/scripting/surftimer/commands.sp
@@ -16,7 +16,6 @@ void CreateCommands()
 	RegConsoleCmd("sm_bhop", Client_AutoBhop, "[surftimer] on/off autobhop");
 	RegConsoleCmd("sm_flashlight", Client_Flashlight, "[surftimer] on/off flashlight");
 	RegConsoleCmd("sm_maptop", Client_MapTop, "[surftimer] displays local map top for a given map");
-	RegConsoleCmd("sm_hidespecs", Client_HideSpecs, "[surftimer] hides spectators from menu/panel");
 	RegConsoleCmd("sm_wr", Client_Wr, "[surftimer] prints records wr in chat");
 	RegConsoleCmd("sm_wrb", Client_Wrb, "[surftimer] prints records wrb in chat");
 	RegConsoleCmd("sm_spec", Client_Spec, "[surftimer] chooses a player who you want to spectate and switch you to spectators");
@@ -197,8 +196,8 @@ void CreateCommands()
 	RegConsoleCmd("sm_replays", Command_PlayRecord, "[surftimer] Set the replay bot to replay a run");
 
 	// Delete records
-	RegAdminCmd("sm_deleterecords", Command_DeleteRecords, g_ZonerFlag, "[SurfTimer] [Zoner] Delete records");
-	RegAdminCmd("sm_dr", Command_DeleteRecords, g_ZonerFlag, "[SurfTimer] [Zoner] Delete records");
+	RegAdminCmd("sm_deleterecords", Command_DeleteRecords, g_ZonerFlag, "[surftimer] [zoner] Delete records");
+	RegAdminCmd("sm_dr", Command_DeleteRecords, g_ZonerFlag, "[surftimer] [zoner] Delete records");
 }
 
 public Action Command_DeleteRecords(int client, int args)
@@ -581,7 +580,7 @@ public Action Command_SaveLocList(int client, int args)
 {
 	if (g_iSaveLocCount < 1)
 	{
-		CPrintToChat(client, "%t", "Commands12", g_szChatPrefix);
+		CPrintToChat(client, "%t", "Commands11", g_szChatPrefix);
 		return Plugin_Handled;
 	}
 
@@ -797,7 +796,7 @@ public void ListBonuses(int client, int type)
 	}
 	else
 	{
-		CPrintToChat(client, "%t", "NoBonusInMap", g_szChatPrefix);
+		CPrintToChat(client, "%t", "NoBonusOnMap", g_szChatPrefix);
 		return;
 	}
 
@@ -850,7 +849,7 @@ public Action Command_ToBonus(int client, int args)
 
 	if (g_mapZoneGroupCount < 2)
 	{
-		CPrintToChat(client, "%t", "NoBonusInMap", g_szChatPrefix);
+		CPrintToChat(client, "%t", "NoBonusOnMap", g_szChatPrefix);
 		return Plugin_Handled;
 	}
 
@@ -924,7 +923,7 @@ public void ListStages(int client, int zonegroup)
 		}
 		if (amount == 0)
 		{
-			AddMenuItem(sMenu, "", "The map is linear.", ITEMDRAW_DISABLED);
+			CPrintToChat(client, "%t", "Commands87", g_szChatPrefix);
 		}
 		else
 		{
@@ -1554,7 +1553,7 @@ public Action Client_BonusTop(int client, int args)
 		case 0: { // !btop
 			if (g_mapZoneGroupCount == 1)
 			{
-				CPrintToChat(client, "%t", "NoBonusFound", g_szChatPrefix);
+				CPrintToChat(client, "%t", "NoBonusOnMap", g_szChatPrefix);
 				CPrintToChat(client, "%t", "BTopUsage", g_szChatPrefix);
 				return Plugin_Handled;
 			}
@@ -1631,7 +1630,7 @@ public Action Client_SWBonusTop(int client, int args)
 		case 0: { // !btop
 			if (g_mapZoneGroupCount == 1)
 			{
-				CPrintToChat(client, "%t", "NoBonusFound", g_szChatPrefix);
+				CPrintToChat(client, "%t", "NoBonusOnMap", g_szChatPrefix);
 				CPrintToChat(client, "%t", "BTopUsage", g_szChatPrefix);
 				return Plugin_Handled;
 			}
@@ -1988,9 +1987,9 @@ public Action Client_Hide(int client, int args)
 {
 	HideMethod(client);
 	if (!g_bHide[client])
-		CPrintToChat(client, "%t", "Hide1", g_szChatPrefix);
+		CPrintToChat(client, "%t", "HidePlayers1", g_szChatPrefix);
 	else
-		CPrintToChat(client, "%t", "Hide2", g_szChatPrefix);
+		CPrintToChat(client, "%t", "HidePlayers2", g_szChatPrefix);
 	return Plugin_Handled;
 }
 
@@ -2347,21 +2346,6 @@ public void PauseMethod(int client)
 	}
 }
 
-public Action Client_HideSpecs(int client, int args)
-{
-	HideSpecs(client);
-	if (g_bShowSpecs[client] == true)
-		CPrintToChat(client, "%t", "HideSpecs1", g_szChatPrefix);
-	else
-		CPrintToChat(client, "%t", "HideSpecs2", g_szChatPrefix);
-	return Plugin_Handled;
-}
-
-public void HideSpecs(int client)
-{
-	g_bShowSpecs[client] = !g_bShowSpecs[client];
-}
-
 public int GoToMenuHandler(Menu menu, MenuAction action, int param1, int param2)
 {
 	if (action == MenuAction_Select)
@@ -2382,7 +2366,7 @@ public int GoToMenuHandler(Menu menu, MenuAction action, int param1, int param2)
 				{
 					if (i == MaxClients)
 					{
-						CPrintToChat(param1, "%t", "Goto4", g_szChatPrefix, szPlayerName);
+						CPrintToChat(param1, "%t", "PlayerNotFound", g_szChatPrefix, szPlayerName);
 						Client_GoTo(param1, 0);
 					}
 				}
@@ -2688,7 +2672,7 @@ public void BonusTopMenu(int client)
 		}
 		else
 		{
-			CPrintToChat(client, "%t", "NoBonusInMap", g_szChatPrefix);
+			CPrintToChat(client, "%t", "NoBonusOnMap", g_szChatPrefix);
 			return;
 		}
 
@@ -3992,7 +3976,7 @@ public Action Command_SelectBonusTime(int client, int args)
 			}
 			else if (g_mapZoneGroupCount == 1)
 			{
-				CReplyToCommand(client, "%t", "BonusNotFound", g_szChatPrefix);
+				CReplyToCommand(client, "%t", "NoBonusOnMap", g_szChatPrefix);
 				return Plugin_Handled;
 			}
 
@@ -4058,7 +4042,7 @@ public Action Command_SelectBonusTime(int client, int args)
 				}
 				else if (g_mapZoneGroupCount == 1)
 				{
-					CReplyToCommand(client, "%t", "BonusNotFound", g_szChatPrefix);
+					CReplyToCommand(client, "%t", "NoBonusOnMap", g_szChatPrefix);
 					return Plugin_Handled;
 				}
 

--- a/addons/sourcemod/scripting/surftimer/cvote.sp
+++ b/addons/sourcemod/scripting/surftimer/cvote.sp
@@ -176,7 +176,7 @@ public int Handle_VoteMenuSetNextMap(Menu menu, MenuAction action, int param1, i
 		}
 		else // No
 		{
-			CPrintToChatAll("%t", "CVote14", g_szChatPrefix);
+			CPrintToChatAll("%t", "CVote12", g_szChatPrefix);
 		}
 	}
 }

--- a/addons/sourcemod/scripting/surftimer/hooks.sp
+++ b/addons/sourcemod/scripting/surftimer/hooks.sp
@@ -244,8 +244,8 @@ public Action Event_OnPlayerSpawn(Handle event, const char[] name, bool dontBroa
 		// Get Speed & Origin
 		g_fLastSpeed[client] = GetSpeed(client);
 		
-		// Give Player Kevlar + Helment
-		GivePlayerItem( client, "item_assaultsuit");
+		// Give Player Kevlar + Helmet
+		GivePlayerItem(client, "item_assaultsuit");
 		
 	}
 	else if (IsFakeClient(client)) 

--- a/addons/sourcemod/scripting/surftimer/mapsettings.sp
+++ b/addons/sourcemod/scripting/surftimer/mapsettings.sp
@@ -227,7 +227,6 @@ public Action Command_SetAnnounceRecord(int client, int args)
 	float setting = StringToFloat(arg);
 	g_fAnnounceRecord = setting;
 	db_updateMapSettings();
-	CPrintToChat(client, "%t", "MSettings5", g_szChatPrefix);
 
 	return Plugin_Handled;
 }

--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -1729,7 +1729,7 @@ public void PrintMapRecords(int client, int type)
 		{
 			if (g_fBonusFastest[i] != 9999999.0) // BONUS
 			{
-				CPrintToChat(client, "%t", "Misc6", g_szChatPrefix, g_szBonusFastest[i], g_szZoneGroupName[i], g_szBonusFastestTime[i], g_szMapName);
+				CPrintToChat(client, "%t", "Misc6", g_szChatPrefix, g_szBonusFastest[i], g_szBonusFastestTime[i], g_szZoneGroupName[i], g_szMapName);
 			}
 		}
 	}
@@ -4128,29 +4128,29 @@ stock void PrintChatBonusStyle (int client, int zGroup, int style, int rank = 0)
 	}
 	if (g_bBonusFirstRecord[client] && g_bBonusSRVRecord[client])
 	{
-		CPrintToChatAll("%t", "Misc37", g_szChatPrefix, szName, g_szStyleRecordPrint[style], g_szZoneGroupName[zGroup]);
+		CPrintToChatAll("%t", "Misc37", g_szChatPrefix, szName, g_szZoneGroupName[zGroup], g_szStyleRecordPrint[style]);
 		if (g_tmpBonusCount[zGroup] == 0)
-			CPrintToChatAll("%t", "Misc38", g_szChatPrefix, szName, g_szStyleRecordPrint[style], g_szZoneGroupName[zGroup], g_szFinalTime[client], g_szFinalTime[client]);
+			CPrintToChatAll("%t", "Misc38", g_szChatPrefix, szName, g_szZoneGroupName[zGroup], g_szStyleRecordPrint[style], g_szFinalTime[client], g_szFinalTime[client]);
 		else
-			CPrintToChatAll("%t", "Misc39", g_szChatPrefix, szName, g_szStyleRecordPrint[style], g_szZoneGroupName[zGroup], g_szFinalTime[client], szRecordDiff, g_StyleMapRankBonus[style][zGroup][client], g_iStyleBonusCount[style][zGroup], g_szFinalTime[client]);
+			CPrintToChatAll("%t", "Misc39", g_szChatPrefix, szName, g_szZoneGroupName[zGroup], g_szStyleRecordPrint[style], g_szFinalTime[client], szRecordDiff, g_StyleMapRankBonus[style][zGroup][client], g_iStyleBonusCount[style][zGroup], g_szFinalTime[client]);
 	}
 	if (g_bBonusPBRecord[client] && g_bBonusSRVRecord[client])
 	{
-		CPrintToChatAll("%t", "Misc37", g_szChatPrefix, szName, g_szStyleRecordPrint[style], g_szZoneGroupName[zGroup]);
-		CPrintToChatAll("%t", "Misc39", g_szChatPrefix, szName, g_szStyleRecordPrint[style], g_szZoneGroupName[zGroup], g_szFinalTime[client], szRecordDiff, g_StyleMapRankBonus[style][zGroup][client], g_iStyleBonusCount[style][zGroup], g_szFinalTime[client]);
+		CPrintToChatAll("%t", "Misc37", g_szChatPrefix, szName, g_szZoneGroupName[zGroup], g_szStyleRecordPrint[style]);
+		CPrintToChatAll("%t", "Misc39", g_szChatPrefix, szName, g_szZoneGroupName[zGroup], g_szStyleRecordPrint[style], g_szFinalTime[client], szRecordDiff, g_StyleMapRankBonus[style][zGroup][client], g_iStyleBonusCount[style][zGroup], g_szFinalTime[client]);
 	}
 	if (g_bBonusPBRecord[client] && !g_bBonusSRVRecord[client])
 	{
 		PlayUnstoppableSound(client);
-		CPrintToChatAll("%t", "Misc40", g_szChatPrefix, szName, g_szStyleRecordPrint[style], g_szZoneGroupName[zGroup], g_szFinalTime[client], g_szBonusTimeDifference[client], g_StyleMapRankBonus[style][zGroup][client], g_iStyleBonusCount[style][zGroup], g_szStyleBonusFastestTime[style][zGroup]);
+		CPrintToChatAll("%t", "Misc40", g_szChatPrefix, szName, g_szZoneGroupName[zGroup], g_szStyleRecordPrint[style], g_szFinalTime[client], g_szBonusTimeDifference[client], g_StyleMapRankBonus[style][zGroup][client], g_iStyleBonusCount[style][zGroup], g_szStyleBonusFastestTime[style][zGroup]);
 	}
 	if (g_bBonusFirstRecord[client] && !g_bBonusSRVRecord[client])
 	{
-		CPrintToChatAll("%t", "Misc41", g_szChatPrefix, szName, g_szStyleRecordPrint[style], g_szZoneGroupName[zGroup], g_szFinalTime[client], g_StyleMapRankBonus[style][zGroup][client], g_iStyleBonusCount[style][zGroup], g_szStyleBonusFastestTime[style][zGroup]);
+		CPrintToChatAll("%t", "Misc41", g_szChatPrefix, szName, g_szZoneGroupName[zGroup], g_szStyleRecordPrint[style], g_szFinalTime[client], g_StyleMapRankBonus[style][zGroup][client], g_iStyleBonusCount[style][zGroup], g_szStyleBonusFastestTime[style][zGroup]);
 	}
 	if (!g_bBonusSRVRecord[client] && !g_bBonusFirstRecord[client] && !g_bBonusPBRecord[client])
 	{
-		CPrintToChatAll("%t", "Misc42", g_szChatPrefix, szName, g_szStyleRecordPrint[style], g_szZoneGroupName[zGroup], g_szFinalTime[client], g_szBonusTimeDifference[client], g_StyleMapRankBonus[style][zGroup][client], g_iStyleBonusCount[style][zGroup], g_szStyleBonusFastestTime[style][zGroup]);
+		CPrintToChatAll("%t", "Misc42", g_szChatPrefix, szName, g_szZoneGroupName[zGroup], g_szStyleRecordPrint[style], g_szFinalTime[client], g_szBonusTimeDifference[client], g_StyleMapRankBonus[style][zGroup][client], g_iStyleBonusCount[style][zGroup], g_szStyleBonusFastestTime[style][zGroup]);
 	}
 
 	CheckBonusStyleRanks(client, zGroup, style);

--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -7744,7 +7744,7 @@ public void db_SelectPlayersBonusRankCallback(Handle owner, Handle hndl, const c
 		int rank;
 		rank = SQL_GetRowCount(hndl);
 
-		CPrintToChatAll("%t", "SQL36", g_szChatPrefix, playername, rank, g_totalPlayerTimes[client], g_szRuntimepro[client], mapname, bonus);
+		CPrintToChatAll("%t", "SQL36", g_szChatPrefix, playername, rank, g_totalPlayerTimes[client], g_szRuntimepro[client], bonus, mapname);
 	}
 }
 

--- a/addons/sourcemod/scripting/surftimer/sql2.sp
+++ b/addons/sourcemod/scripting/surftimer/sql2.sp
@@ -1052,7 +1052,6 @@ public void SQL_SelectCPRTimeCallback(Handle owner, Handle hndl, const char[] er
 
 		char szQuery[512];
 		Format(szQuery, sizeof(szQuery), "SELECT cp1, cp2, cp3, cp4, cp5, cp6, cp7, cp8, cp9, cp10, cp11, cp12, cp13, cp14, cp15, cp16, cp17, cp18, cp19, cp20, cp21, cp22, cp23, cp24, cp25, cp26, cp27, cp28, cp29, cp30, cp31, cp32, cp33, cp34, cp35 FROM ck_checkpoints WHERE steamid = '%s' AND mapname LIKE '%c%s%c' AND zonegroup = 0;", g_szSteamID[client], PERCENT, g_szCPRMapName[client], PERCENT);
-		CPrintToChat(client, "%s", g_szCPRMapName[client]);
 		SQL_TQuery(g_hDb, SQL_SelectCPRCallback, szQuery, pack, DBPrio_Low);
 	}
 	else
@@ -1081,12 +1080,6 @@ public void SQL_SelectCPRCallback(Handle owner, Handle hndl, const char[] error,
 			g_fClientCPs[client][i] = SQL_FetchFloat(hndl, i - 1);
 		}
 		db_selectCPRTarget(pack);
-	}
-	else
-	{
-		ResetPack(pack);
-		int client = ReadPackCell(pack);
-		CPrintToChat(client, "2", LIMEGREEN, WHITE);
 	}
 }
 
@@ -1128,12 +1121,6 @@ public void SQL_SelectCPRTargetCallback(Handle owner, Handle hndl, const char[] 
 		SQL_FetchString(hndl, 1, g_szTargetCPR[client], sizeof(g_szTargetCPR));
 		g_fTargetTime[client] = SQL_FetchFloat(hndl, 3);
 		db_selectCPRTargetCPs(szSteamId, pack);
-	}
-	else
-	{
-		ResetPack(pack);
-		int client = ReadPackCell(pack);
-		CPrintToChat(client, "3", LIMEGREEN, WHITE);
 	}
 }
 
@@ -1193,12 +1180,7 @@ public void SQL_SelectCPRTargetCPsCallback(Handle owner, Handle hndl, const char
 		SetMenuOptionFlags(menu, MENUFLAG_BUTTON_EXIT);
 		DisplayMenu(menu, client, MENU_TIME_FOREVER);
 	}
-	else
-	{
-		ResetPack(pack);
-		int client = ReadPackCell(pack);
-		CPrintToChat(client, "4", LIMEGREEN, WHITE);
-	}
+
 	CloseHandle(pack);
 }
 

--- a/addons/sourcemod/scripting/surftimer/timer.sp
+++ b/addons/sourcemod/scripting/surftimer/timer.sp
@@ -117,7 +117,6 @@ public Action CKTimer1(Handle timer)
 				if (g_bFirstTeamJoin[client])
 				{
 					g_bFirstTeamJoin[client] = false;
-					CreateTimer(0.0, StartMsgTimer, client, TIMER_FLAG_NO_MAPCHANGE);
 					CreateTimer(10.0, WelcomeMsgTimer, client, TIMER_FLAG_NO_MAPCHANGE);
 					CreateTimer(70.0, HelpMsgTimer, client, TIMER_FLAG_NO_MAPCHANGE);
 				}
@@ -176,7 +175,7 @@ public Action CKTimer2(Handle timer)
 				case 120:CPrintToChatAll("%t", "TimeleftMinutes", g_szChatPrefix, g_szMapName, timeleft / 60);
 				case 60:CPrintToChatAll("%t", "TimeleftSeconds", g_szChatPrefix, g_szMapName, timeleft);
 				case 30:CPrintToChatAll("%t", "TimeleftSeconds", g_szChatPrefix, g_szMapName, timeleft);
-				case 15:CPrintToChatAll("%t", "TimeleftSeconds", g_szChatPrefix, g_szMapName, timeleft);
+				case 10:CPrintToChatAll("%t", "TimeleftSeconds", g_szChatPrefix, g_szMapName, timeleft);
 				case  - 1:CPrintToChatAll("%t", "TimeleftCounter", g_szChatPrefix, g_szMapName, 3);
 				case  - 2:CPrintToChatAll("%t", "TimeleftCounter", g_szChatPrefix, g_szMapName, 2);
 				case  - 3:
@@ -475,16 +474,6 @@ public Action AdvertTimer(Handle timer)
 		}
 	}
 	return Plugin_Continue;
-}
-
-public Action StartMsgTimer(Handle timer, any client)
-{
-	if (IsValidClient(client) && !IsFakeClient(client))
-	{
-		PrintMapRecords(client, 0);
-		PrintMapRecords(client, 99);
-	}
-	return Plugin_Handled;
 }
 
 public Action CenterMsgTimer(Handle timer, any client)

--- a/addons/sourcemod/translations/surftimer.phrases.txt
+++ b/addons/sourcemod/translations/surftimer.phrases.txt
@@ -55,26 +55,6 @@
 		"#format"	"{1:s}"
 		"en"		"{1} Type {lightgreen}!wrcp {default}to see your stage times"
 	}
-	"ZoneVisAll"
-	{
-		"#format"	"{1:s}"
-		"en"		"{1} The zone is visible for ALL"
-	}
-	"ZoneVisT"
-	{
-		"#format"	"{1:s}"
-		"en"		"{1} The zone is visible for Terrorists"
-	}
-	"ZoneVisCT"
-	{
-		"#format"	"{1:s}"
-		"en"		"{1} The zone is visible for Counter-Terrorists"
-	}
-	"ZoneVisInv"
-	{
-		"#format"	"{1:s}"
-		"en"		"{1} The zone is invisible"
-	}
 	"AvgTime"
 	{
 		"#format"	"{1:s},{2:s},{3:i}"
@@ -163,67 +143,67 @@
 	"NewMapRecord"
 	{
 		"#format"	"{1:s},{2:s}"
-		"en"		"{1} {yellow}{2} {default}has beaten the {blue}MAP RECORD"
+		"en"		"{1} {yellow}{2} {default}beat the map record!"
 	}
 	"ReplayFinishingMsg"
 	{
 		"#format"	"{1:s},{2:s},{3:s}"
-		"en"		"{1} {yellow}{2}{default} finished the map in [{lightgreen}{3}{default}]"
+		"en"		"{1} {yellow}{2}{default} has finished in [{lightgreen}{3}{default}]"
 	}
 	"ReplayFinishingMsgBonus"
 	{
 		"#format"	"{1:s},{2:s},{3:s},{4:s}"
-		"en"		"{1} {yellow}{2}{default} finished the {orange}{3}{default} in [{lightgreen}{4}{default}]"
+		"en"		"{1} {yellow}{2}{default} has finished [{orange}{3}{default}] in [{lightgreen}{4}{default}]"
 	}
 	"MapFinished1"
 	{
 		"#format"	"{1:s},{2:s},{3:s},{4:i},{5:i},{6:s},{7:s}"
-		"en"		"{1} {yellow}{2}{default} finished the map in [{lightgreen}{3}{default}]. [Rank: {lightgreen}{4}/{5} {default}{6} | Record: {lightgreen}{7}{default}]"
+		"en"		"{1} {yellow}{2}{default} finished in {lightgreen}{3}{default}. [Rank: {lightgreen}{4}/{5} {default}{6} | Record: {lightgreen}{7}{default}]"
 	}
 	"MapFinished3"
 	{
 		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:i},{6:i},{7:s},{8:s}"
-		"en"		"{1} {yellow}{2}{default} finished the map in [{lightgreen}{3}{default}]. Improving their best time by [{lightgreen}{4}{default}]. [Rank: {lightgreen}{5}/{6} {default}{7} | Record: {lightgreen}{8}{default}]"
+		"en"		"{1} {yellow}{2}{default} finished in {lightgreen}{3}{default}. Improving their best time by [{lightgreen}{4}{default}]. [Rank: {lightgreen}{5}/{6} {default}{7} | Record: {lightgreen}{8}{default}]"
 	}
 	"MapFinished5"
 	{
 		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:i},{6:i},{7:s},{8:s}"
-		"en"		"{1} {yellow}{2}{default} finished the map in [{lightgreen}{3}{default}]. Missing their best time by [{red}{4}{default}]. [Rank: {lightgreen}{5}/{6} {default}{7} | Record: {lightgreen}{8}{default}]"
+		"en"		"{1} {yellow}{2}{default} finished in {lightgreen}{3}{default}. Missing their best time by [{red}{4}{default}]. [Rank: {lightgreen}{5}/{6} {default}{7} | Record: {lightgreen}{8}{default}]"
 	}
 	"BonusFinished1"
 	{
 		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:s},{6:i},{7:i},{8:s}"
-		"en"		"{1} {yellow}{2} {default}finished the {orange}{3} {default}in {red}{4}{default}. Missing their best time by [{red}{5}{default}]. [Rank: {lightgreen}{6}/{7} {default}| Record: {lightgreen}{8}{default}]"
+		"en"		"{1} {yellow}{2}{default} finished [{orange}{3}{default}] in {red}{4}{default}. Missing their best time by [{red}{5}{default}]. [Rank: {lightgreen}{6}/{7} {default}| Record: {lightgreen}{8}{default}]"
 	}
 	"BonusFinished2"
 	{
 		"#format"	"{1:s},{2:s},{3:s}"
-		"en"		"{1} {yellow}{2} {default}has beaten the {orange}{3} RECORD"
+		"en"		"{1} {yellow}{2} {default}beat the [{orange}{3}{default}] record!"
 	}
 	"BonusFinished3"
 	{
 		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:s}"
-		"en"		"{1} {yellow}{2} {default}finished the {orange}{3} {default}in {lightgreen}{4}{default}. [Rank: {lightgreen}1/1 {default}| Record: {lightgreen}{5}{default}]"
+		"en"		"{1} {yellow}{2}{default} finished [{orange}{3}{default}] in {lightgreen}{4}{default}. [Rank: {lightgreen}1/1 {default}| Record: {lightgreen}{5}{default}]"
 	}
 	"BonusFinished4"
 	{
 		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:s},{6:i},{7:i},{8:s}"
-		"en"		"{1} {yellow}{2} {default}finished the {orange}{3} {default}in {lightgreen}{4}{default}. Improving the best time by {lightgreen}{5}{default}. [Rank: {lightgreen}{6}/{7} {default}| Record: {lightgreen}{8}{default}]"
+		"en"		"{1} {yellow}{2}{default} finished [{orange}{3}{default}] in {lightgreen}{4}{default}. Improving the best time by {lightgreen}{5}{default}. [Rank: {lightgreen}{6}/{7} {default}| Record: {lightgreen}{8}{default}]"
 	}
 	"BonusFinished5"
 	{
 		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:s},{6:i},{7:i},{8:s}"
-		"en"		"{1} {yellow}{2} {default}finished the {orange}{3} {default}in {lightgreen}{4}{default}. Improving the best time by {lightgreen}{5}{default}. [Rank: {lightgreen}{6}/{7} {default}| Record: {lightgreen}{8}{default}]"
+		"en"		"{1} {yellow}{2}{default} finished [{orange}{3}{default}] in {lightgreen}{4}{default}. Improving the best time by {lightgreen}{5}{default}. [Rank: {lightgreen}{6}/{7} {default}| Record: {lightgreen}{8}{default}]"
 	}
 	"BonusFinished6"
 	{
 		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:s},{6:i},{7:i},{8:s}"
-		"en"		"{1} {yellow}{2} {default}finished the {orange}{3} {default}in {lightgreen}{4}{default}. Improving their best time by {lightgreen}{5}{default}. [Rank: {lightgreen}{6}/{7} {default}| Record: {lightgreen}{8}{default}]"
+		"en"		"{1} {yellow}{2}{default} finished [{orange}{3}{default}] in {lightgreen}{4}{default}. Improving their best time by {lightgreen}{5}{default}. [Rank: {lightgreen}{6}/{7} {default}| Record: {lightgreen}{8}{default}]"
 	}
 	"BonusFinished7"
 	{
 		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:i},{6:i},{7:s}"
-		"en"		"{1} {yellow}{2} {default}finished the {orange}{3} {default}in {lightgreen}{4}{default}. [Rank: {lightgreen}{5}/{6} {default}| Record: {lightgreen}{7}{default}]"
+		"en"		"{1} {yellow}{2}{default} finished [{orange}{3}{default}] in {lightgreen}{4}{default}. [Rank: {lightgreen}{5}/{6} {default}| Record: {lightgreen}{7}{default}]"
 	}
 	"PlayerNotFound"
 	{
@@ -265,11 +245,6 @@
 		"#format"	"{1:s}"
 		"en"		"{1} You must {lightgreen}!stop {default}your timer to use {lightgreen}!goto"
 	}
-	"Goto4"
-	{
-		"#format"	"{1:s},{2:s}"
-		"en"		"{1} Player {2} not found"
-	}
 	"Goto5"
 	{
 		"#format"	"{1:s},{2:s}"
@@ -283,22 +258,22 @@
 	"Goto7"
 	{
 		"#format"	"{1:s},{2:s}"
-		"en"		"{1} You can't teleport to {2} because he/she was not on ground"
+		"en"		"{1} You can't teleport to {2} because the player was not on the ground"
 	}
 	"RadioCommandsDisabled"
 	{
 		"#format"	"{1:s}"
 		"en"		"{1} Radio commands are disabled"
 	}
-	"Hide1"
+	"HidePlayers1"
 	{
 		"#format"	"{1:s}"
-		"en"		"{1} Hide other players disabled"
+		"en"		"{1} Hide players disabled"
 	}
-	"Hide2"
+	"HidePlayers2"
 	{
 		"#format"	"{1:s}"
-		"en"		"{1} Hide other players enabled"
+		"en"		"{1} Hide players enabled"
 	}
 	"Pause1"
 	{
@@ -388,19 +363,19 @@
 	"BPress4"
 	{
 		"#format"	"{1:s},{2:s},{3:s}"
-		"en"		"{1} {yellow}{2} {default}finished the bonus in [{blue}{3}{default}] in practice mode!"
+		"en"		"{1} {yellow}{2}{default} finished the bonus in [{blue}{3}{default}] in practice mode!"
 	}
 	"BPress5"
 	{
 		"#format"	"{1:s},{2:s},{3:s}"
-		"en"		"{1} {yellow}{2} {default}finished the map in [{blue}{3}{default}] in practice mode!"
+		"en"		"{1} {yellow}{2}{default} finished the map in [{blue}{3}{default}] in practice mode!"
 	}
 	"BPress6"
 	{
 		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:s},{6:i},{7:i},{8:s}"
-		"en"		"{1} {yellow}{2}{default} finished the {blue}map {red}{3} {default}in [{lightgreen}{4}{default}]. Missing their best time by [{red}{5}{default}]. [Rank: {lightgreen}{6}/{7} {default}| Record: {lightgreen}{8}{default}]"
+		"en"		"{1} {yellow}{2}{default} finished {red}{3} {default}in {lightgreen}{4}{default}. Missing their best time by [{red}{5}{default}]. [Rank: {lightgreen}{6}/{7} {default}| Record: {lightgreen}{8}{default}]"
 	}
-	"BPress7"
+	"BPress7" //come back aven
 	{
 		"#format"	"{1:s},{2:d}"
 		"en"		"{1} You have earned {lightgreen}{2} {default}credits"
@@ -412,8 +387,8 @@
 	}
 	"MSettings1"
 	{
-		"#format"	"{1:s},{2:f}"
-		"en"		"{1} Type the maxvelocity you want to set"
+		"#format"	"{1:s}"
+		"en"		"{1} Type the max velocity you want to set"
 	}
 	"MSettings2"
 	{
@@ -428,12 +403,7 @@
 	"MSettings4"
 	{
 		"#format"	"{1:s},{2:f}"
-		"en"		"{1} Current Announce Record: {2} [0 = All Finishes, 1 = PB Only, 2 = WR Only]"
-	}
-	"MSettings5"
-	{
-		"#format"	"{1:s}"
-		"en"		"{1} [0 = All Finishes, 1 = PB Only, 2 = WR Only]"
+		"en"		"{1} Usage: sm_announcerecord <0/1/2> [0 = All Finishes, 1 = PB Only, 2 = WR Only] [Current Announce Record: {2}]"
 	}
 	"MSettings6"
 	{
@@ -500,30 +470,15 @@
 		"#format"	"{1:s}"
 		"en"		"{1} There are no save locs, use sm_saveloc to make one"
 	}
-	"Commands12"
-	{
-		"#format"	"{1:s}"
-		"en"		"{1} There are no save locs, use sm_saveloc"
-	}
 	"Commands13"
 	{
 		"#format"	"{1:s},{2:d}"
 		"en"		"{1} Set saveloc id to #{2}"
 	}
-	"NoBonusInMap"
+	"NoBonusOnMap"
 	{
 		"#format"	"{1:s}"
-		"en"		"{1} There are no bonuses in this map"
-	}
-	"NoBonusFound"
-	{
-		"#format"	"{1:s}"
-		"en"		"{1} No bonus found on this map"
-	}
-	"BonusNotFound"
-	{
-		"#format"	"{1:s}"
-		"en"		"{1} Bonus not found"
+		"en"		"{1} There are no bonuses on this map"
 	}
 	"InvalidBonusID"
 	{
@@ -573,7 +528,7 @@
 	"Commands38"
 	{
 		"#format"	"{1:s}"
-		"en"		"{1} Turning on spec list on module 1 and disabling other modules will make the side hud have the old functionality"
+		"en"		"{1} In order to restore the old functionality, set module 1 to spec list."
 	}
 	"Commands39"
 	{
@@ -608,7 +563,7 @@
 	"Commands45"
 	{
 		"#format"	"{1:s}"
-		"en"		"{1} This map is linear. WRCP is not available"
+		"en"		"{1} This is a linear map. WRCP is not available"
 	}
 	"Commands46"
 	{
@@ -665,13 +620,11 @@
 		"#format"	"{1:s},{2:s}"
 		"en"		"{1} Player {yellow}{2} {default}not found"
 	}
-
 	"NoZoneAccess"
 	{
 		"#format"	"{1:s}"
 		"en"		"{1} You don't have access to the zones menu"
 	}
-
 	"Commands58"
 	{
 		"#format"	"{1:s}"
@@ -682,7 +635,7 @@
 		"#format"	"{1:s},{2:s},{3:f},{4:f},{5:f}"
 		"en"		"{1} Teleporting to {2} at {3} {4} {5}"
 	}
-	"Commands60"
+	"Commands60" //come back aven
 	{
 		"#format"	"{1:s}"
 		"en"		"{1} Type the bonus number"
@@ -797,6 +750,11 @@
 		"#format"	"{1:s}"
 		"en"		"{1} g_hTriggerMultiple is null!"
 	}
+	"Commands87"
+	{
+		"#format"	"{1:s}"
+		"en"		"{1} This is a linear map."
+	}
 	"BotInUse"
 	{
 		"#format"	"{1:s},{2:s}"
@@ -857,11 +815,6 @@
 		"#format"	"{1:s},{2:s}"
 		"en"		"{1} Set next map to {2}"
 	}
-	"CVote14"
-	{
-		"#format"	"{1:s}"
-		"en"		"{1} Vote failed"
-	}
 	"SQLTime1"
 	{
 		"#format"	"{1:s},{2:s}"
@@ -870,12 +823,12 @@
 	"VIP1"
 	{
 		"#format"	"{1:s}"
-		"en"		"{1} Usage: sm_vip \"steamid\" \"viplvl\""
+		"en"		"{1} Usage: sm_givevip \"steamid\" \"viplvl\""
 	}
 	"VIP2"
 	{
 		"#format"	"{1:s}"
-		"en"		"{1} Usage: sm_vip \"steamid\""
+		"en"		"{1} Usage: sm_removevip \"steamid\""
 	}
 	"VIP3"
 	{
@@ -914,7 +867,7 @@
 	"SQLTwo4.2"
 	{
 		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:s}"
-		"en"		"{1} {yellow}{2} {default}has beaten the {yellow}{3} {default}map record in the {lime}{4} {default}server with a time of {lime}{5}"
+		"en"		"{1} {yellow}{2} {default}beat the {blue}{3} {default}map record in the {lime}{4} {default}server with a time of {lime}{5}"
 	}
 	"SQLTwo4.3"
 	{
@@ -980,11 +933,6 @@
 		"#format"	"{1:s}"
 		"en"		"{1} No spawnpoint to delete!"
 	}
-	"Admin10"
-	{
-		"#format"	"{1:s}"
-		"en"		"{1} See console for more commands"
-	}
 	"Admin11"
 	{
 		"#format"	"{1:s}"
@@ -1003,7 +951,7 @@
 	"SurfZones3"
 	{
 		"#format"	"{1:s}"
-		"en"		"{1} Zones are reloaded"
+		"en"		"{1} Zones have been reloaded"
 	}
 	"SurfZones4"
 	{
@@ -1068,7 +1016,7 @@
 	"Hooks4"
 	{
 		"#format"	"{1:s},{2:s},{3:f}"
-		"en"		"{1} {2} max velocity set to {3}"
+		"en"		"{1} {blue}{2} {default}max velocity set to {3}"
 	}
 	"Hooks5"
 	{
@@ -1148,12 +1096,12 @@
 	"Misc5"
 	{
 		"#format"	"{1:s},{2:s},{3:s},{4:s}"
-		"en"		"{1} {yellow}{2} {default}holds the record with time: {lightgreen}{3} {default}on {blue}{4}"
+		"en"		"{1} {yellow}{2} {default}holds the record with a time of {lightgreen}{3} {default}on {blue}{4}"
 	}
 	"Misc6"
 	{
 		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:s}"
-		"en"		"{1} {yellow}{2} {default}holds the {orange}{3} {default}record with time: {lightgreen}{4} {default}on {blue}{5}"
+		"en"		"{1} {yellow}{2} {default}holds the record with a time of {lightgreen}{3} {default}for {orange}{4} {default}on {blue}{5}"
 	}
 	"Misc7"
 	{
@@ -1293,47 +1241,47 @@
 	"Misc34"
 	{
 		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:i},{6:i},{7:s}"
-		"en"		"{1} {yellow}{2}{default} finished the {blue}map {red}{3} {default}in [{lightgreen}{4}{default}]. [Rank: {lightgreen}{5}/{6} {default}| Record: {lightgreen}{7}{default}"
+		"en"		"{1} {yellow}{2}{default} finished {red}{3} {default}in [{lightgreen}{4}{default}]. [Rank: {lightgreen}{5}/{6} {default}| Record: {lightgreen}{7}{default}"
 	}
 	"Misc35"
 	{
 		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:s},{6:i},{7:i},{8:s}"
-		"en"		"{1} {yellow}{2}{default} finished the {blue}map {red}{3} {default}in [{lightgreen}{4}{default}]. Improving their best time by [{lightgreen}{5}{default}]. [Rank: {lightgreen}{6}/{7} {default}| Record: {lightgreen}{8}{default}]"
+		"en"		"{1} {yellow}{2}{default} finished {red}{3} {default}in [{lightgreen}{4}{default}]. Improving their best time by [{lightgreen}{5}{default}]. [Rank: {lightgreen}{6}/{7} {default}| Record: {lightgreen}{8}{default}]"
 	}
 	"Misc36"
 	{
 		"#format"	"{1:s},{2:s},{3:s}"
-		"en"		"{1} {yellow}{2}{default} has beaten the {red}{3} {blue}MAP RECORD"
+		"en"		"{1} {yellow}{2}{default} beat the {red}{3} {default}map record"
 	}
 	"Misc37"
 	{
 		"#format"	"{1:s},{2:s},{3:s},{4:s}"
-		"en"		"{1} {yellow}{2}{default} has beaten the {red}{3} {orange}{4} RECORD"
+		"en"		"{1} {yellow}{2}{default} beat the [{orange}{3}{default}] {red}{4} {default}record"
 	}
 	"Misc38"
 	{
 		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:s},{6:s}"
-		"en"		"{1} {yellow}{2} {default}finished the {red}{3} {orange}{4} {default}in {lightgreen}{5}{default}. [Rank: {lightgreen}1/1 {default}| Record: {lightgreen}{6}{default}]"
+		"en"		"{1} {yellow}{2} {default}finished [{orange}{3}{default}] {red}{4} {default}in {lightgreen}{5}{default}. [Rank: {lightgreen}1/1 {default}| Record: {lightgreen}{6}{default}]"
 	}
 	"Misc39"
 	{
 		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:s},{6:s},{7:i},{8:i},{9:s}"
-		"en"		"{1} {yellow}{2} {default}finished the {red}{3} {orange}{4} {default}in {lightgreen}{5}{default}. Improving the best time by {lightgreen}{6}{default}. [Rank: {lightgreen}{7}/{8} {default}| Record: {lightgreen}{9}{default}]"
+		"en"		"{1} {yellow}{2} {default}finished [{orange}{3}{default}] {red}{4} {default}in {lightgreen}{5}{default}. Improving the best time by {lightgreen}{6}{default}. [Rank: {lightgreen}{7}/{8} {default}| Record: {lightgreen}{9}{default}]"
 	}
 	"Misc40"
 	{
 		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:s},{6:s},{7:i},{8:i},{9:s}"
-		"en"		"{1} {yellow}{2} {default}finished the {red}{3} {orange}{4} {default}in {lightgreen}{5}{default}. Improving their best time by {lightgreen}{6}{default}. [Rank: {lightgreen}{7}/{8} {default}| Record: {lightgreen}{9}{default}]"
+		"en"		"{1} {yellow}{2} {default}finished [{orange}{3}{default}] {red}{4} {default}in {lightgreen}{5}{default}. Improving their best time by {lightgreen}{6}{default}. [Rank: {lightgreen}{7}/{8} {default}| Record: {lightgreen}{9}{default}]"
 	}
 	"Misc41"
 	{
 		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:s},{6:i},{7:i},{8:s}"
-		"en"		"{1} {yellow}{2} {default}finished the {red}{3} {orange}{4} {default}in {lightgreen}{5}{default}. [Rank: {lightgreen}{6}/{7} {default}| Record: {lightgreen}{8}{default}]"
+		"en"		"{1} {yellow}{2} {default}finished [{orange}{3}{default}] {red}{4} {default}in {lightgreen}{5}{default}. [Rank: {lightgreen}{6}/{7} {default}| Record: {lightgreen}{8}{default}]"
 	}
 	"Misc42"
 	{
 		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:s},{6:s},{7:i},{8:i},{9:s}"
-		"en"		"{1} {yellow}{2} {default}finished the {red}{3} {orange}{4} {default}in {red}{5}{default}. Missing their best time by {red}{6}{default}. [Rank: {lightgreen}{7}/{8} {default}| Record: {lightgreen}{9}{default}]"
+		"en"		"{1} {yellow}{2} {default}finished [{orange}{3}{default}] {red}{4} {default}in {lightgreen}{5}{default}. Missing their best time by {red}{6}{default}. [Rank: {lightgreen}{7}/{8} {default}| Record: {lightgreen}{9}{default}]"
 	}
 	"Misc43"
 	{
@@ -1527,10 +1475,10 @@
 	}
 	"SQL36"
 	{
-		"#format"	"{1:s},{2:s},{3:i},{4:i},{5:s},{6:s},{7:i}"
-		"en"		"{1} {yellow}{2} {default}is ranked {lightgreen}{3}/{4} {default}with a time of {lightgreen}{5} {default}on {blue}{6} {orange}bonus {7}"
+		"#format"	"{1:s},{2:s},{3:i},{4:i},{5:s},{6:i},{7:s}"
+		"en"		"{1} {yellow}{2} {default}is ranked {lightgreen}{3}/{4} {default}with a time of {lightgreen}{5} {default}for {orange}bonus {6} {default}on {blue}{7}"
 	}
-	"SQL37"
+	"SQL37" //come back aven // see NoMapFound
 	{
 		"#format"	"{1:s},{2:s}"
 		"en"		"{1} No result found for {blue}{2}"


### PR DESCRIPTION
Changes:
- Removed chat messages displayed when the player initially spawns (sm_wr and sm_wrb).
- Removed chat messages displayed when the player starts their initially run (sm_avg).
- Removed legacy sm_hidespecs command due to it having no use.
- Fixed sm_deleterecords/sm_dr displaying incorrectly in the help menu.
- Removed some debug messages.
- Changed many timer-specific chat messages.
- Adjusted other various translation file entries.

Note: The commands (sm_wr, sm_wrb and sm_avg) are still available, but are not displayed by default.

Note 2: If you see an issue with the timer-specific changes contact me on discord (aveniccii#6540). I'll make sure to fix it in my next pull request.

Note 2.5: The timer-specific changes are not fully finished so messages may minorly differ from one another despite previously being similar.