### PR TITLE
Remove Generic from VIP

### DIFF
--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -4539,7 +4539,7 @@ bool IsPlayerVip(int client, bool admin = true, bool reply = true)
 {
 	if (admin)
 	{
-		if (CheckCommandAccess(client, "", ADMFLAG_GENERIC))
+		if (CheckCommandAccess(client, "", ADMFLAG_ROOT))
 			return true;
 	}
 


### PR DESCRIPTION
All staff basically have access to VIP features, should be set to root then Owners can define if they want staff to be using these features.